### PR TITLE
Test enhancement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,15 +3,13 @@ language: php
 sudo: false
 
 php:
-    - 5.3
-    - 5.4
-    - 5.5
-    - 5.6
-    - hhvm
+    - 7.0
+    - 7.1
+    - 7.2
+    - 7.3
 
 before_script:
-    - wget http://getcomposer.org/composer.phar
-    - php composer.phar install --dev --no-interaction
+    - composer install --no-interaction
 
 script:
     - mkdir -p build/logs

--- a/composer.json
+++ b/composer.json
@@ -10,19 +10,23 @@
         }
     ],
     "require": {
-        "php": ">=5.3.2"
+        "php": ">=7.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "~4.0",
-        "satooshi/php-coveralls": "^0.6.1",
+        "phpunit/phpunit": "^6.5",
+        "php-coveralls/php-coveralls": "^0.6.1",
         "ext-bcmath": "*"
     },
     "suggest": {
-        "ext-bcmath": "*"
+        "ext-bcmath": "Let float number calculation correctly"
     },
     "autoload": {
         "psr-4": {
-            "Maba\\Component\\Math\\": "src",
+            "Maba\\Component\\Math\\": "src"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
             "Maba\\Component\\Math\\Tests\\": "test"
         }
     }

--- a/src/BcMath.php
+++ b/src/BcMath.php
@@ -34,10 +34,11 @@ class BcMath implements BasicMathInterface
     {
         $this->validator->validateNumber($first);
         $this->validator->validateNumber($second);
-        $result = bcdiv($first, $second, $this->scale);
-        if ($result === null) {
+        if ($second == 0) {
             throw new DivisionByZeroException(sprintf('Division by zero (%s / %s)', $first, $second));
         }
+        $result = bcdiv($first, $second, $this->scale);
+
         return $result;
     }
 
@@ -69,4 +70,4 @@ class BcMath implements BasicMathInterface
         return bcmod($first, $second);
     }
 
-} 
+}

--- a/test/BcMathTest.php
+++ b/test/BcMathTest.php
@@ -3,21 +3,23 @@
 
 namespace Maba\Component\Math\Tests;
 
+use PHPUnit\Framework\TestCase;
 use Maba\Component\Math\BcMath;
 use Maba\Component\Math\NumberValidatorInterface;
+use Maba\Component\Math\Exception\DivisionByZeroException;
 
-class BcMathTest extends \PHPUnit_Framework_TestCase
+class BcMathTest extends TestCase
 {
     /**
      * @var BcMath
      */
     protected $math;
 
-    public function setUp()
+    protected function setUp()
     {
         /** @var NumberValidatorInterface $validator */
-        $validator = $this->getMock('Maba\Component\Math\NumberValidatorInterface');
-        $this->math = new BcMath(6, $validator);
+        $validator = $this->getMockBuilder('Maba\Component\Math\NumberValidatorInterface');
+        $this->math = new BcMath(6, $validator->getMock());
     }
 
     /**
@@ -54,6 +56,14 @@ class BcMathTest extends \PHPUnit_Framework_TestCase
     public function testDiv($result, $first, $second)
     {
         $this->assertSameNumber($result, $this->math->div($first, $second));
+    }
+
+    public function testDivOnDivisionByZero()
+    {
+        $this->expectException(DivisionByZeroException::class);
+        $this->expectExceptionMessage('Division by zero (0 / 0)');
+
+        $this->math->div(0, 0);
     }
 
     /**
@@ -175,4 +185,4 @@ class BcMathTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($expected, $actual, $message);
     }
 
-} 
+}

--- a/test/MathTest.php
+++ b/test/MathTest.php
@@ -3,6 +3,7 @@
 
 namespace Maba\Component\Math\Tests;
 
+use PHPUnit\Framework\TestCase;
 use Maba\Component\Math\BcMath;
 use Maba\Component\Math\Math;
 use Maba\Component\Math\MathInterface;
@@ -11,18 +12,18 @@ use Maba\Component\Math\NumberValidatorInterface;
 /**
  * Tests Math together with BcMath to test use-cases without mocking
  */
-class MathTest extends \PHPUnit_Framework_TestCase
+class MathTest extends TestCase
 {
     /**
      * @var MathInterface
      */
     protected $math;
 
-    public function setUp()
+    protected function setUp()
     {
         /** @var NumberValidatorInterface $validator */
-        $validator = $this->getMock('Maba\Component\Math\NumberValidatorInterface');
-        $this->math = new Math(new BcMath(6, $validator));
+        $validator = $this->getMockBuilder('Maba\Component\Math\NumberValidatorInterface');
+        $this->math = new Math(new BcMath(6, $validator->getMock()));
     }
 
     /**
@@ -82,6 +83,12 @@ class MathTest extends \PHPUnit_Framework_TestCase
     public function testCeil($result, $operand, $precision = 0)
     {
         $this->assertSameNumber($result, $this->math->ceil($operand, $precision));
+    }
+
+    public function testLte()
+    {
+        $this->assertTrue($this->math->isLte(10, 20));
+        $this->assertFalse($this->math->isLte(20, 10));
     }
 
     public function negateProvider()
@@ -232,4 +239,4 @@ class MathTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($expected, $actual, $message);
     }
 
-} 
+}

--- a/test/NumberFormatterTest.php
+++ b/test/NumberFormatterTest.php
@@ -3,24 +3,25 @@
 
 namespace Maba\Component\Math\Tests;
 
+use PHPUnit\Framework\TestCase;
 use Maba\Component\Math\BcMath;
 use Maba\Component\Math\Math;
 use Maba\Component\Math\NumberFormatter;
 use Maba\Component\Math\NumberFormatterInterface;
 use Maba\Component\Math\NumberValidatorInterface;
 
-class NumberFormatterTest extends \PHPUnit_Framework_TestCase
+class NumberFormatterTest extends TestCase
 {
     /**
      * @var NumberFormatterInterface
      */
     protected $numberFormatter;
 
-    public function setUp()
+    protected function setUp()
     {
         /** @var NumberValidatorInterface $validator */
-        $validator = $this->getMock('Maba\Component\Math\NumberValidatorInterface');
-        $math = new Math(new BcMath(6, $validator));
+        $validator = $this->getMockBuilder('Maba\Component\Math\NumberValidatorInterface');
+        $math = new Math(new BcMath(6, $validator->getMock()));
         $this->numberFormatter = new NumberFormatter($math, '.', '');
     }
 
@@ -95,7 +96,7 @@ class NumberFormatterTest extends \PHPUnit_Framework_TestCase
             array('1cd234cd567ab22', '1234567.221', 2, 'ab', 'cd'),
 
             array('1234567.22', '1234567.221', 2),
-            
+
             array('0', '-0'),
             array('-1', '-1'),
             array('-2', '-2.11'),
@@ -143,4 +144,4 @@ class NumberFormatterTest extends \PHPUnit_Framework_TestCase
         );
     }
 
-} 
+}

--- a/test/NumberValidatorTest.php
+++ b/test/NumberValidatorTest.php
@@ -2,17 +2,18 @@
 
 namespace Maba\Component\Math\Tests;
 
+use PHPUnit\Framework\TestCase;
 use Maba\Component\Math\NumberValidator;
 use Maba\Component\Math\NumberValidatorInterface;
 
-class NumberValidatorTest extends \PHPUnit_Framework_TestCase
+class NumberValidatorTest extends TestCase
 {
     /**
      * @var NumberValidatorInterface
      */
     protected $numberValidator;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->numberValidator = new NumberValidator();
     }
@@ -87,4 +88,4 @@ class NumberValidatorTest extends \PHPUnit_Framework_TestCase
         );
     }
 
-} 
+}


### PR DESCRIPTION
# Changed log

- Drop the `php-5.x` support because the official team doesn't support these versions.
- Update the PHPUnit versions to be compatible with the `php-7.x` versions.
- Add some tests to test some methods.
- Using the class-based PHPUnit namespace to support the latest PHPUnit versions.
- According to the [PHPUnit Fixtures reference](https://phpunit.readthedocs.io/en/latest/fixtures.html?highlight=fixtures), the `setUp` method should be protected, not public.